### PR TITLE
fix: remove platform-specific `lightningcss-linux-x64-gnu` from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "clsx": "^2.1.1",
         "framer-motion": "^12.34.0",
-        "lightningcss-linux-x64-gnu": "^1.31.1",
         "lucide-react": "^0.563.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2946,24 +2945,6 @@
       ],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
-      "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
-      "cpu": [
-        "x64"
-      ],
       "os": [
         "linux"
       ],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "framer-motion": "^12.34.0",
-    "lightningcss-linux-x64-gnu": "^1.31.1",
     "lucide-react": "^0.563.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
## Summary

Fixes #1 — Removes the platform-specific `lightningcss-linux-x64-gnu` package from `dependencies`, which causes `npm install` to fail on non-Linux-x64 platforms.

## Problem

`lightningcss-linux-x64-gnu` (added in `399f79d`) is a **Linux x64-only binary**. When listed as a direct dependency, npm enforces its platform constraint and blocks installation on:

- macOS (ARM64 / x64)
- Windows (all architectures)
- Linux ARM64

```
npm error code EBADPLATFORM
npm error notsup Unsupported platform for lightningcss-linux-x64-gnu@1.31.1:
  wanted {"os":"linux","cpu":"x64"} (current: {"os":"darwin","cpu":"arm64"})
```

## Fix

Remove `lightningcss-linux-x64-gnu` from `package.json` `dependencies`. The correct platform-specific binary is automatically resolved by the build toolchain (Vite → Tailwind CSS → Lightning CSS) via `optionalDependencies` — no manual installation is needed.

## Changes

- `package.json`: Removed `"lightningcss-linux-x64-gnu": "^1.31.1"` from `dependencies`
- `package-lock.json`: Regenerated without the platform-specific entry

## Verification

After the fix, tested on macOS ARM64 (darwin arm64):

```bash
$ npm install
added 199 packages, and audited 200 packages in 3s

$ npm run build
# tsc -b && vite build completes successfully
```

The Docker build (Linux x64) should remain unaffected, as Vite/Tailwind CSS will continue to resolve `lightningcss-linux-x64-gnu` automatically via `optionalDependencies`.

## Notes

If the original addition in `399f79d` was intended to fix a Docker build issue, the root cause is likely that `optionalDependencies` were skipped during `npm install` (e.g., `npm install --omit=optional`). In that case, the Dockerfile's install command should be checked instead.